### PR TITLE
Use iterator instead of index to operate on slice

### DIFF
--- a/src/day1.rs
+++ b/src/day1.rs
@@ -58,12 +58,9 @@ impl Solver {
 }
 
 fn count_increases(input: &[u32]) -> u32 {
-    let last = input.len() - 1;
     let mut counter = 0;
-    // iterate to the second to last element in input
-    for (idx, number) in input[..last].iter().enumerate() {
-        // increment counter if current number is less than next number
-        if number < &input[idx + 1] {
+    for pair in input.windows(2) {
+        if pair[0] < pair[1] {
             counter += 1
         }
     }
@@ -71,13 +68,9 @@ fn count_increases(input: &[u32]) -> u32 {
 }
 
 fn count_range_increases(input: &[u32], window_size: usize) -> u32 {
-    let last = input.len() - window_size;
-    let mut sums: Vec<u32> = Vec::new();
-    // iterate to the last element with a valid window size
-    for (idx, _number) in input[..=last].iter().enumerate() {
-        let end = idx + window_size;
-        // generate sum
-        sums.push(input[idx..end].iter().sum());
-    }
+    let sums: Vec<u32> = input
+        .windows(window_size)
+        .map(|depths| depths.iter().sum())
+        .collect();
     count_increases(&sums)
 }


### PR DESCRIPTION
* Indices can lead to off by one errors or accidental out of bounds.
* Iterators protect us from aforementioned errors, are more readable, and are more idiomatic.